### PR TITLE
MAINT: Minor compiler fixes

### DIFF
--- a/libs/tbdefs.hpp
+++ b/libs/tbdefs.hpp
@@ -21,6 +21,20 @@
 #include <complex>
 #include <time.h>
 
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const std::valarray<T>& v)
+{
+    os << "[";
+    if (v.size() > 0) {
+        os << v[0];
+        for (size_t i = 1; i < v.size(); ++i) {
+            os << ", " << v[i];
+        }
+    }
+    os << "]";
+    return os;
+}
+
 /**************************************
  *          MACROS & DEFINES          *
  **************************************/

--- a/make.in
+++ b/make.in
@@ -9,7 +9,7 @@ MAKEDEPEND=g++ -M $(CXXFLAGS)
 # Lapack includes and linking
 
 ILAPACK=
-LLAPACK=-llapack
+LLAPACK=-lopenblas
 
 TBSRC=../libs/
 LDFLAGS=-L$(TBSRC) -ltoolbox $(LLAPACK)

--- a/tools/dimproj.cpp
+++ b/tools/dimproj.cpp
@@ -124,7 +124,9 @@ int main(int argc, char**argv)
     else
     {
       csv2floats(fdhd,tfpars);  fhdpars=tfpars;
-      std::cerr<<"high-dim pars"<<tfpars<<"\n";
+      std::cerr << "high-dim pars";
+      toolbox::operator<<(std::cerr, tfpars);
+      std::cerr <<"\n";
       if (tfpars.size()==2)
       {
         opts.tfunH.set_mode(NLDRGamma,tfpars);
@@ -142,7 +144,9 @@ int main(int argc, char**argv)
     else
     {
       csv2floats(fdld,tfpars); fldpars=tfpars;
-      std::cerr<<"lo-dim pars"<<tfpars<<"\n";
+      std::cerr<<"lo-dim pars";
+      toolbox::operator<<(std::cerr, tfpars);
+      std::cerr <<"\n";
       if (tfpars.size()==2)
       {
         opts.tfunL.set_mode(NLDRGamma,tfpars);

--- a/tools/dimred.cpp
+++ b/tools/dimred.cpp
@@ -140,8 +140,10 @@ int main(int argc, char**argv)
     else 
     {
       csv2floats(fdhd,tfpars);  fhdpars=tfpars; 
-      std::cerr<<"high-dim pars"<<tfpars<<"\n";     
-      if (tfpars.size()==2) 
+      std::cerr << "high-dim pars";
+      toolbox::operator<<(std::cerr, tfpars);
+      std::cerr <<"\n";
+      if (tfpars.size()==2)
       {
         iteropts.tfunH.set_mode(NLDRGamma,tfpars);       
       }
@@ -160,8 +162,10 @@ int main(int argc, char**argv)
     else 
     {
       csv2floats(fdld,tfpars); fldpars=tfpars;      
-      std::cerr<<"lo-dim pars"<<tfpars<<"\n";     
-      if (tfpars.size()==2) 
+      std::cerr<<"lo-dim pars";
+      toolbox::operator<<(std::cerr, tfpars);
+      std::cerr <<"\n";
+      if (tfpars.size()==2)
       {
         iteropts.tfunL.set_mode(NLDRGamma,tfpars);  
       }
@@ -200,7 +204,9 @@ int main(int argc, char**argv)
 
     std::cerr<<"hey "<<itermode<<" "<<iteropts.minmode<<"\n";
     std::valarray<double> sat(0.0,2); csv2floats(tempopts,sat);
-    std::cerr<<" simulated annealing ops: "<<sat<<"\n";
+    std::cerr << " simulated annealing ops: ";
+    toolbox::operator<<(std::cerr, sat);
+    std::cerr<<"\n";
     iteropts.saopts.temp_init=sat[0]; iteropts.saopts.temp_final=sat[1];
     iteropts.ptopts.temp_init=sat[0]; iteropts.ptopts.temp_final=sat[1]; 
     iteropts.ptopts.temp_factor=ptfac; iteropts.ptopts.replica=npt;


### PR DESCRIPTION
There's one in `ioparser` but this was enough for me to get around:

```bash
In file included from dimreduce.hpp:9:
../libs/tbdefs.hpp: In instantiation of 'std::ostream& toolbox::mpiostream::operator<<(T) [with T = std::valarray<double>; std::ostream = std::basic_ostream<char>]':
../libs/minsearch.hpp:758:18:   required from 'void toolbox::sim_annealing(FCLASS&, const std::valarray<double>&, std::valarray<double>&, double&, AnnealingOptions, std::valarray<std::valarray<double> >, RNG) [with FCLASS = NLDRITERChi; RNG = MTRndUniform; AnnealingOptions = _AnnealingOpts]'
../libs/minsearch.hpp:809:39:   required from 'void toolbox::sim_annealing(FCLASS&, const std::valarray<double>&, std::valarray<double>&, double&, AnnealingOptions, std::valarray<std::valarray<double> >) [with FCLASS = NLDRITERChi; AnnealingOptions = _AnnealingOpts]'
libdimred.cpp:1603:30:   required from here
../libs/tbdefs.hpp:413:18: error: no match for 'operator<<' (operand types are 'std::ostream' {aka 'std::basic_ostream<char'} and 'std::valarray<double>')
  413 |         return os<<data;
      |                ~~^~~~~~
In file included from /home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/iostream:41,
                 from ../libs/tbdefs.hpp:19:
/home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/ostream:110:7: note: candidate: 'std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]'
  110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
      |       ^~~~~~~~
/home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/ostream:110:36: note:   no known conversion for argument 1 from 'std::valarray<double>' to 'std::basic_ostream<char>::__ostream_type& (*)(std::basic_ostream<char>::__ostream_type&)' {aka 'std::basic_ostream<char>& (*)(std::basic_ostream<char>&)'}
  110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
      |                  ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/ostream:119:7: note: candidate: 'std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ios_type& (*)(__ios_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>; __ios_type = std::basic_ios<char>]'
  119 |       operator<<(__ios_type& (*__pf)(__ios_type&))
      |       ^~~~~~~~
/home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/ostream:119:32: note:   no known conversion for argument 1 from 'std::valarray<double>' to 'std::basic_ostream<char>::__ios_type& (*)(std::basic_ostream<char>::__ios_type&)' {aka 'std::basic_ios<char>& (*)(std::basic_ios<char>&)'}
  119 |       operator<<(__ios_type& (*__pf)(__ios_type&))
      |                  ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/home/rgoswami/Git/Github/epfl/lab-cosmo/rgShowcase/.pixi/envs/eon/lib/gcc/x86_64-conda-linux-gnu/13.3.0/include/c++/ostream:129:7: note: candidate: 'std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::ios_base& (*)(std::ios_base&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]'
  129 |       operator<<(ios_base& (*__pf) (ios_base&))
```

The (re)definition also required changes to distinguish between the `ioparser` variant.